### PR TITLE
mx-samba-config-lib: don't assume service command available

### DIFF
--- a/scripts/mx-samba-config-lib
+++ b/scripts/mx-samba-config-lib
@@ -11,8 +11,7 @@ if [ -x /usr/sbin/update-rc.d ]; then
     update-rc.d nmbd remove
     update-rc.d smbd defaults
     update-rc.d nmbd defaults
-fi
-if [ -x /usr/bin/systemctl ]; then
+elif [ -x /usr/bin/systemctl ]; then
     systemctl unmask smbd
     systemctl unmask nmbd
     systemctl enable smbd
@@ -26,8 +25,7 @@ disablesamba()
 if [ -x /usr/sbin/update-rc.d ]; then
     update-rc.d smbd remove
     update-rc.d nmbd remove
-fi
-if [ -x /usr/bin/systemctl ]; then
+elif [ -x /usr/bin/systemctl ]; then
     systemctl disable smbd
     systemctl disable nmbd
     systemctl mask smbd
@@ -69,8 +67,15 @@ if [ -x /usr/bin/systemctl ]; then
     systemctl unmask smbd
     systemctl unmask nmbd
 fi
-service smbd start
-service nmbd start
+
+if [ -x /usr/bin/service ]; then
+    service smbd start
+    service nmbd start
+elif [ -x /usr/bin/systemctl ]; then
+    systemctl start smbd
+    systemctl start nmbd
+fi
+
 if [[ -x /usr/bin/systemctl && $MASKED == "masked" ]]; then
     systemctl mask smbd
     systemctl mask nmbd
@@ -82,8 +87,15 @@ exit $?
 
 stopsamba()
 {
-service smbd stop
-service nmbd stop
+
+if [ -x /usr/bin/service ]; then
+    service smbd stop
+    service nmbd stop
+elif [ -x /usr/bin/systemctl ]; then
+    systemctl stop smbd
+    systemctl stop nmbd
+fi
+
 exit $?
 
 }

--- a/scripts/mx-samba-config-lib
+++ b/scripts/mx-samba-config-lib
@@ -16,7 +16,7 @@ if [ -x /usr/bin/systemctl ]; then
     systemctl unmask smbd
     systemctl unmask nmbd
     systemctl enable smbd
-    systemctl enable nmbd	
+    systemctl enable nmbd
 fi
 }
 
@@ -27,7 +27,7 @@ if [ -x /usr/sbin/update-rc.d ]; then
     update-rc.d smbd remove
     update-rc.d nmbd remove
 fi
-if [ -x /usr/bin/systemctl ]; then    
+if [ -x /usr/bin/systemctl ]; then
     systemctl disable smbd
     systemctl disable nmbd
     systemctl mask smbd
@@ -37,7 +37,7 @@ fi
 
 addsambauser()
 {
-	
+
 echo -ne "$pass\n$pass" | smbpasswd -as "$user"
 exit $?
 
@@ -48,15 +48,15 @@ removesambauser()
 
 pdbedit --delete "$user"
 exit $?
-	
+
 }
 
 changesambapasswd()
 {
-	
+
 echo -ne "$pass\n$pass" | smbpasswd -U "$user"
 exit $?
-	
+
 }
 
 
@@ -70,14 +70,14 @@ if [ -x /usr/bin/systemctl ]; then
     systemctl unmask nmbd
 fi
 service smbd start
-service nmbd start	
+service nmbd start
 if [[ -x /usr/bin/systemctl && $MASKED == "masked" ]]; then
     systemctl mask smbd
     systemctl mask nmbd
-fi 
+fi
 
 exit $?
-	
+
 }
 
 stopsamba()
@@ -97,20 +97,20 @@ case $1 in
     stopsamba)  stopsamba
                  ;;
     enablesamba)  enablesamba
-                 ;;      
+                 ;;
     disablesamba)  disablesamba
                  ;;
     addsambauser)  user="$3"
                    pass="$2"
-                   addsambauser   
-                   ;;  
+                   addsambauser
+                   ;;
     removesambauser)  user="$2"
-                      removesambauser   
-                   ;;    
+                      removesambauser
+                   ;;
     changesambapasswd)  user="$3"
                    pass="$2"
-                   changesambapasswd   
-                   ;;  
+                   changesambapasswd
+                   ;;
 esac
 }
 


### PR DESCRIPTION
non-debian-based distros may not have `service` command.  This PR uses `systemctl` to start/stop the daemon when `service` is unavailable.